### PR TITLE
added small cli shim to call heroku plugin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,36 @@ complete with pipeline stages, email deployment hook, and optional http deployme
 
 ---
 
-## Installation
+## "New" Heroku Toolbelt
 
-`heroku plugins:install https://github.com/kapost/heroku-cabbage.git`
+### Installation
 
-## Example Usage
+```bash
+$ git clone git@github.com:kapost/heroku-cabbage.git
+```
 
-`heroku cabbage:provision myapp --hook https://hooks.slack.com/blah/token`
+### Example Usage
 
-### Ignore Errors
+```bash
+$ cd heroku-cabbage
+$ bin/cabbage-provision myapp --hook https://hooks.slack.com/blah/token
+```
+
+## "Old" Heroku Toolbelt
+
+### Installation
+
+```bash
+$ heroku plugins:install https://github.com/kapost/heroku-cabbage.git
+```
+
+### Example Usage
+
+```bash
+$ heroku cabbage:provision myapp --hook https://hooks.slack.com/blah/token
+```
+
+## Ignore Errors
 
 To continue provisioning when one command fails, use `--continue-on-error`.
 This is useful when provisioning staging apps but pilyr and production have

--- a/bin/cabbage-provision
+++ b/bin/cabbage-provision
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+
+module Heroku
+  module Command
+    class CommandFailed < StandardError; end
+
+    class Base
+      attr_accessor :args
+
+      def initialize(args)
+        self.args = args
+      end
+
+      protected
+
+      def error(message)
+        puts message
+        exit(-1)
+      end
+
+      def confirm(message)
+        STDOUT.write(message)
+        STDOUT.write(" ")
+        STDIN.gets.chomp.casecmp("y").zero?
+      end
+
+      def options
+        @options ||= parse_args(args)
+      end
+
+      private
+
+      def parse_args(args)
+        {}.tap do |hash|
+          "#{args.join(" ")} ".scan(/--(.*?)(?:\s+|$)(.*?\s+|$)?/).map do |m|
+            hash[m[0].strip.tr("-", "_").to_sym] = m[1].strip
+          end
+        end
+      end
+
+      attr_writer :args
+    end
+  end
+end
+
+trap("SIGINT") do
+  STDOUT.write("\n")
+  STDOUT.flush
+  exit(-1)
+end
+
+require File.expand_path("../../lib/kapost-provision/commands/cabbage", __FILE__)
+
+cmd = Heroku::Command::Cabbage.new(ARGV.dup)
+cmd.provision
+
+# vim: set ts=2 sw=2 sts=2 expandtab noeol:


### PR DESCRIPTION
@brandonc The Heroku Toolbelt has been since rewritten in JS (with node) so this "plugin" is no longer usable.

I added a small "script" in the bin directory to allow calling the "heroku plugin command", which uses the same arguments, etc.

```bash
bin/cabbage-provision myapp --hook https://hooks.slack.com/blah/token
```

I kept the old code intact, just in case some people still use the old toolbelt written in Ruby.